### PR TITLE
fix: dctl module name

### DIFF
--- a/tools/dctl/cmd/api.go
+++ b/tools/dctl/cmd/api.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steady-bytes/tools/dctl/cmd/api"
+	"github.com/steady-bytes/draft/tools/dctl/cmd/api"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/api/build.go
+++ b/tools/dctl/cmd/api/build.go
@@ -6,10 +6,10 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"github.com/steady-bytes/tools/dctl/config"
-	"github.com/steady-bytes/tools/dctl/docker"
-	e "github.com/steady-bytes/tools/dctl/execute"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/docker"
+	e "github.com/steady-bytes/draft/tools/dctl/execute"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"

--- a/tools/dctl/cmd/api/clean.go
+++ b/tools/dctl/cmd/api/clean.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/steady-bytes/tools/dctl/config"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/api/init.go
+++ b/tools/dctl/cmd/api/init.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
-	"github.com/steady-bytes/tools/dctl/config"
-	"github.com/steady-bytes/tools/dctl/docker"
-	e "github.com/steady-bytes/tools/dctl/execute"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/docker"
+	e "github.com/steady-bytes/draft/tools/dctl/execute"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/config.go
+++ b/tools/dctl/cmd/config.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steady-bytes/tools/dctl/cmd/config"
+	"github.com/steady-bytes/draft/tools/dctl/cmd/config"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/docs.go
+++ b/tools/dctl/cmd/docs.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"

--- a/tools/dctl/cmd/infra.go
+++ b/tools/dctl/cmd/infra.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steady-bytes/tools/dctl/cmd/infra"
+	"github.com/steady-bytes/draft/tools/dctl/cmd/infra"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/infra/clean.go
+++ b/tools/dctl/cmd/infra/clean.go
@@ -1,8 +1,8 @@
 package infra
 
 import (
-	"github.com/steady-bytes/tools/dctl/docker"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/docker"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/infra/init.go
+++ b/tools/dctl/cmd/infra/init.go
@@ -3,8 +3,8 @@ package infra
 import (
 	"fmt"
 
-	"github.com/steady-bytes/tools/dctl/docker"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/docker"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/infra/start.go
+++ b/tools/dctl/cmd/infra/start.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/steady-bytes/tools/dctl/docker"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/docker"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/infra/status.go
+++ b/tools/dctl/cmd/infra/status.go
@@ -3,8 +3,8 @@ package infra
 import (
 	"context"
 
-	"github.com/steady-bytes/tools/dctl/docker"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/docker"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"

--- a/tools/dctl/cmd/infra/stop.go
+++ b/tools/dctl/cmd/infra/stop.go
@@ -1,8 +1,8 @@
 package infra
 
 import (
-	"github.com/steady-bytes/tools/dctl/docker"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/docker"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/pipelines.go
+++ b/tools/dctl/cmd/pipelines.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steady-bytes/tools/dctl/cmd/pipelines"
+	"github.com/steady-bytes/draft/tools/dctl/cmd/pipelines"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/pipelines/clean.go
+++ b/tools/dctl/cmd/pipelines/clean.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/steady-bytes/tools/dctl/config"
-	"github.com/steady-bytes/tools/dctl/execute"
-	"github.com/steady-bytes/tools/dctl/input"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/execute"
+	"github.com/steady-bytes/draft/tools/dctl/input"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/pipelines/dashboard.go
+++ b/tools/dctl/cmd/pipelines/dashboard.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/steady-bytes/tools/dctl/execute"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/execute"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/pipelines/init.go
+++ b/tools/dctl/cmd/pipelines/init.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/steady-bytes/tools/dctl/config"
-	"github.com/steady-bytes/tools/dctl/execute"
-	"github.com/steady-bytes/tools/dctl/input"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/execute"
+	"github.com/steady-bytes/draft/tools/dctl/input"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/pipelines/run.go
+++ b/tools/dctl/cmd/pipelines/run.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/steady-bytes/tools/dctl/config"
-	"github.com/steady-bytes/tools/dctl/execute"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/execute"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/project.go
+++ b/tools/dctl/cmd/project.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steady-bytes/tools/dctl/cmd/project"
+	"github.com/steady-bytes/draft/tools/dctl/cmd/project"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/project/import.go
+++ b/tools/dctl/cmd/project/import.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/steady-bytes/tools/dctl/config"
-	"github.com/steady-bytes/tools/dctl/input"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/input"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/tools/dctl/cmd/project/init.go
+++ b/tools/dctl/cmd/project/init.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/steady-bytes/tools/dctl/input"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/input"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/tools/dctl/cmd/project/set.go
+++ b/tools/dctl/cmd/project/set.go
@@ -1,8 +1,8 @@
 package project
 
 import (
-	"github.com/steady-bytes/tools/dctl/config"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/release.go
+++ b/tools/dctl/cmd/release.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steady-bytes/tools/dctl/cmd/release"
+	"github.com/steady-bytes/draft/tools/dctl/cmd/release"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/release/module.go
+++ b/tools/dctl/cmd/release/module.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/steady-bytes/tools/dctl/execute"
-	"github.com/steady-bytes/tools/dctl/input"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/execute"
+	"github.com/steady-bytes/draft/tools/dctl/input"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/Masterminds/semver/v3"
 )

--- a/tools/dctl/cmd/root.go
+++ b/tools/dctl/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"path/filepath"
 
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/tools/dctl/cmd/run.go
+++ b/tools/dctl/cmd/run.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/steady-bytes/tools/dctl/cmd/run"
+	"github.com/steady-bytes/draft/tools/dctl/cmd/run"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/cmd/run/run.go
+++ b/tools/dctl/cmd/run/run.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/steady-bytes/tools/dctl/config"
-	e "github.com/steady-bytes/tools/dctl/execute"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/config"
+	e "github.com/steady-bytes/draft/tools/dctl/execute"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/dctl/config/config.go
+++ b/tools/dctl/config/config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/viper"
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 )
 
 type (

--- a/tools/dctl/docker/docker.go
+++ b/tools/dctl/docker/docker.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"

--- a/tools/dctl/execute/exec.go
+++ b/tools/dctl/execute/exec.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os/exec"
 
-	"github.com/steady-bytes/tools/dctl/output"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 )
 
 func ExecuteCommand(ctx context.Context, name string, c output.Color, cmd *exec.Cmd) error {

--- a/tools/dctl/go.mod
+++ b/tools/dctl/go.mod
@@ -1,4 +1,4 @@
-module github.com/steady-bytes/tools/dctl
+module github.com/steady-bytes/draft/tools/dctl
 
 go 1.21
 

--- a/tools/dctl/main.go
+++ b/tools/dctl/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/steady-bytes/tools/dctl/cmd"
+	"github.com/steady-bytes/draft/tools/dctl/cmd"
 )
 
 func main() {


### PR DESCRIPTION
The module name in `dctl`'s go.mod was incorrect. Fixing that so you can run `go install github.com/draft/tools/dctl@latest`.