### PR TITLE
fix: module names in `services/`

### DIFF
--- a/services/core/blueprint/go.mod
+++ b/services/core/blueprint/go.mod
@@ -1,4 +1,4 @@
-module github.com/steady-bytes/draft/blueprint
+module github.com/steady-bytes/draft/services/core/blueprint
 
 go 1.21.3
 

--- a/services/core/blueprint/main.go
+++ b/services/core/blueprint/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"embed"
 
-	kv "github.com/steady-bytes/draft/blueprint/key_value"
-	sd "github.com/steady-bytes/draft/blueprint/service_discovery"
+	kv "github.com/steady-bytes/draft/services/core/blueprint/key_value"
+	sd "github.com/steady-bytes/draft/services/core/blueprint/service_discovery"
 
 	"github.com/steady-bytes/draft/pkg/chassis"
 	"github.com/steady-bytes/draft/pkg/loggers/zerolog"

--- a/services/core/blueprint/service_discovery/controller.go
+++ b/services/core/blueprint/service_discovery/controller.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	sdv1 "github.com/steady-bytes/draft/api/core/registry/service_discovery/v1"
-	kv "github.com/steady-bytes/draft/blueprint/key_value"
 	"github.com/steady-bytes/draft/pkg/chassis"
+	kv "github.com/steady-bytes/draft/services/core/blueprint/key_value"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/services/core/eventer/go.mod
+++ b/services/core/eventer/go.mod
@@ -1,3 +1,3 @@
-module github.com/steady-bytes/draft/services/eventer
+module github.com/steady-bytes/draft/services/core/eventer
 
 go 1.21.3


### PR DESCRIPTION
Some services still had module names that were not namespaced to their respective folders.