### PR TITLE
feat: `dctl` improvements

### DIFF
--- a/tools/dctl/cmd/config.go
+++ b/tools/dctl/cmd/config.go
@@ -15,4 +15,5 @@ var configCommand = &cobra.Command{
 func init() {
 	// add parent
 	rootCmd.AddCommand(configCommand)
+	configCommand.Flags().BoolVarP(&config.Force, "force", "f", false, "overwrite existing config if already exists")
 }

--- a/tools/dctl/cmd/config/config.go
+++ b/tools/dctl/cmd/config/config.go
@@ -3,43 +3,42 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/steady-bytes/draft/tools/dctl/output"
+)
+
+var (
+	Force bool
 )
 
 func Config(cmd *cobra.Command, args []string) error {
-	err := createConfigFile()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func createConfigFile() error {
-	// get home directory
+	// build config file path
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
-	// build config file path
 	fileName := filepath.Join(home, ".config", "dctl", "config.yaml")
 
-	// create if not exists
-	_, err = os.Stat(fileName)
-	if os.IsNotExist(err) {
+	v := viper.New()
+	v.Set("current", "")
 
-		// make sure the directory exists
-		err = os.MkdirAll(filepath.Join(home, ".config", "dctl"), 0755)
+	if Force {
+		err = v.WriteConfigAs(fileName)
 		if err != nil {
 			return err
 		}
-
-		// create the file
-		file, err := os.Create(fileName)
+	} else {
+		err = v.SafeWriteConfigAs(fileName)
 		if err != nil {
+			if strings.Contains(err.Error(), "Already Exists") {
+				output.Println("Config file already exists. Provide --force/-f flag to overwrite.")
+				return nil
+			}
 			return err
 		}
-		defer file.Close()
 	}
 
 	return nil

--- a/tools/dctl/cmd/project/import.go
+++ b/tools/dctl/cmd/project/import.go
@@ -13,6 +13,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	defaultAPIImageName     = "ghcr.io/steady-bytes/draft-api-builder:main"
+	defaultAPIContainerName = "draft-api-builder"
+)
+
 func Import(cmd *cobra.Command, args []string) error {
 	Path, err := filepath.Abs(Path)
 	if err != nil {
@@ -34,6 +39,10 @@ func Import(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	viper.Set(fmt.Sprintf("projects.%s.root", name), Path)
+
+	// set default api builder image/container
+	viper.Set(fmt.Sprintf("projects.%s.api.image_name", name), defaultAPIImageName)
+	viper.Set(fmt.Sprintf("projects.%s.api.container_name", name), defaultAPIContainerName)
 
 	// write project to config
 	err = viper.WriteConfig()

--- a/tools/dctl/cmd/release/module.go
+++ b/tools/dctl/cmd/release/module.go
@@ -6,15 +6,12 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steady-bytes/draft/tools/dctl/config"
 	"github.com/steady-bytes/draft/tools/dctl/execute"
 	"github.com/steady-bytes/draft/tools/dctl/input"
 	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/Masterminds/semver/v3"
-)
-
-const (
-	trunkBranch = "main"
 )
 
 var (
@@ -35,8 +32,8 @@ func Module(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	if branchString != trunkBranch {
-		output.Println("You are currently on branch %s, not the trunk branch %s. Would you like to proceed? (yes/NO)", branchString, trunkBranch)
+	if branchString != config.CurrentProject().TrunkBranch {
+		output.Println("You are currently on branch %s, not the trunk branch %s. Would you like to proceed? (yes/NO)", branchString, config.CurrentProject().TrunkBranch)
 		if !input.ConfirmDefaultDeny() {
 			output.Println("Cancelled")
 			return nil
@@ -44,7 +41,7 @@ func Module(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// git fetch to update all local tags
-	command = exec.Command("git", "fetch")
+	command = exec.Command("git", "fetch", "--tags")
 	err = execute.ExecuteCommand(ctx, "git", output.Blue, command)
 	if err != nil {
 		return err

--- a/tools/dctl/config/config.go
+++ b/tools/dctl/config/config.go
@@ -14,8 +14,14 @@ type (
 		Projects map[string]Project
 	}
 	Project struct {
-		Repo string
-		Root string
+		Repo        string
+		Root        string
+		TrunkBranch string
+		API         API `mapstructure:"api"`
+	}
+	API struct {
+		ImageName     string `mapstructure:"image_name"`
+		ContainerName string `mapstructure:"container_name"`
 	}
 )
 

--- a/tools/dctl/docker/docker.go
+++ b/tools/dctl/docker/docker.go
@@ -77,6 +77,7 @@ func (d *dockerController) BuildImage(ctx context.Context, path, image string) e
 }
 
 func (d *dockerController) PullImage(ctx context.Context, image string) error {
+	output.Println("Pulling image: %s", image)
 	resp, err := d.cli.ImagePull(ctx, image, types.ImagePullOptions{})
 	if err != nil {
 		return err

--- a/tools/dctl/docs/dctl_api.md
+++ b/tools/dctl/docs/dctl_api.md
@@ -18,6 +18,5 @@ Commands for managing the draft API (protobufs)
 
 * [dctl](dctl.md)	 - dctl (Draft Controller) is the built-in CLI for managing everything in Draft
 * [dctl api build](dctl_api_build.md)	 - Compile all protobuf files
-* [dctl api clean](dctl_api_clean.md)	 - Clean up all compiled (generated) protobuf files
 * [dctl api init](dctl_api_init.md)	 - Build the Docker image that compiles protobufs
 

--- a/tools/dctl/docs/dctl_config.md
+++ b/tools/dctl/docs/dctl_config.md
@@ -9,7 +9,8 @@ dctl config [flags]
 ### Options
 
 ```
-  -h, --help   help for config
+  -f, --force   overwrite existing config if already exists
+  -h, --help    help for config
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
A few small improvements to `dctl`:
- Changed to using the pre-built `draft-api-builder` Docker image
- Moved the container and image names into the per-project config
- Updated the `dctl config` command to use `viper` to initialize the file (and added a --force option)
- Moved the trunk branch constant into the per-project config
- Added a `--tags` to the `git fetch` during module release
- Added a log specifying which image is being pulled during the PullImage() call
