### PR TITLE
fix: `dctl` defaults

### DIFF
--- a/tools/dctl/cmd/project/import.go
+++ b/tools/dctl/cmd/project/import.go
@@ -16,6 +16,7 @@ import (
 const (
 	defaultAPIImageName     = "ghcr.io/steady-bytes/draft-api-builder:main"
 	defaultAPIContainerName = "draft-api-builder"
+	defaultTrunkBranch      = "main"
 )
 
 func Import(cmd *cobra.Command, args []string) error {
@@ -40,9 +41,7 @@ func Import(cmd *cobra.Command, args []string) error {
 	}
 	viper.Set(fmt.Sprintf("projects.%s.root", name), Path)
 
-	// set default api builder image/container
-	viper.Set(fmt.Sprintf("projects.%s.api.image_name", name), defaultAPIImageName)
-	viper.Set(fmt.Sprintf("projects.%s.api.container_name", name), defaultAPIContainerName)
+	setDefaults(name)
 
 	// write project to config
 	err = viper.WriteConfig()

--- a/tools/dctl/cmd/project/init.go
+++ b/tools/dctl/cmd/project/init.go
@@ -91,6 +91,8 @@ func Init(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	setDefaults(name)
+
 	// write project to config
 	err = viper.WriteConfig()
 	if err != nil {
@@ -127,4 +129,10 @@ func writeFiles(dir string) error {
 	}
 
 	return nil
+}
+
+func setDefaults(name string) {
+	viper.Set(fmt.Sprintf("projects.%s.api.image_name", name), defaultAPIImageName)
+	viper.Set(fmt.Sprintf("projects.%s.api.container_name", name), defaultAPIContainerName)
+	viper.Set(fmt.Sprintf("projects.%s.trunk_branch", name), defaultTrunkBranch)
 }

--- a/tools/dctl/config/config.go
+++ b/tools/dctl/config/config.go
@@ -16,7 +16,7 @@ type (
 	Project struct {
 		Repo        string
 		Root        string
-		TrunkBranch string
+		TrunkBranch string `mapstructure:"trunk_branch"`
 		API         API `mapstructure:"api"`
 	}
 	API struct {


### PR DESCRIPTION
Fixing some config defaults for `dctl project` commands. The TrunkBranch wasn't being set and wasn't being read properly and the API Docker values weren't being set properly during `project init`.