### PR TITLE
feat: services CD and Docker steps in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/node_modules
+**/dist
+.vscode
+**/.vscode
+.git
+.gitignore
+Dockerfile
+.dockerignore

--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -93,7 +93,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/draft-${{ steps.info.outputs.domain}}-${{ steps.info.outputs.service }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-${{ steps.info.outputs.domain}}-${{ steps.info.outputs.service }}
           tags: |
             type=sha
             type=edge,branch=main

--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -1,0 +1,120 @@
+name: services - CD
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - services/**
+
+env:
+  REGISTRY: ${{ vars.REGISTRY || 'ghcr.io' }}
+  TARGET_PLATFORMS: linux/amd64,linux/arm64
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # changed:
+  #   name: Prepare
+  #   uses: ./.github/workflows/changes.yml
+  #   with:
+  #     path: services
+  #     dir_names_max_depth: 2
+
+  # build-and-test:
+  #   name: Build-Test (${{ matrix.service-path }})
+  #   # needs: [changed]
+  #   runs-on: ubuntu-latest
+  #   # if: needs.changed.outputs.any_changed == 'true'
+  #   strategy:
+  #     matrix:
+  #       go-version: ['1.21.x']
+  #       # service-path: ${{ fromJSON(needs.changed.outputs.matrix) }}
+  #       service-path: [ 'examples/crud', 'examples/echo']
+  #   steps:
+  #     - uses: actions/checkout@v4
+
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 18
+  #         cache-dependency-path: services/${{ matrix.service-path }}/web-client/package-lock.json
+
+  #     - name: Install Node dependencies
+  #       run: |
+  #         cd services/${{ matrix.service-path }}/web-client &&
+  #         npm i -D @swc/cli @swc/core &&
+  #         npm install
+
+  #     - name: Build web-client
+  #       run: |
+  #         cd services/${{ matrix.service-path }}/web-client &&
+  #         npm run build
+
+  #     - uses: actions/setup-go@v5
+  #       with:
+  #         go-version: ${{ matrix.go-version }}
+  #         cache-dependency-path: services/${{ matrix.service-path }}/go.sum
+
+  #     - name: Test
+  #       working-directory: services/${{ matrix.service-path }}
+  #       run: go test ./...
+
+  #     - name: Build
+  #       working-directory: services/${{ matrix.service-path }}
+  #       run: go build main.go
+
+  docker-image:
+    name: Docker Image (${{ matrix.service-path }})
+    # needs: [changed]
+    runs-on: ubuntu-latest
+    # if: needs.changed.outputs.any_changed == 'true'
+    strategy:
+      matrix:
+        # service-path: ${{ fromJSON(needs.changed.outputs.matrix) }}
+        service-path: [ 'examples/crud', 'examples/echo']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract service info
+        id: info
+        run: |
+          echo "domain=$(dirname ${{ matrix.service-path }})" >> $GITHUB_OUTPUT
+          echo "service=$(basename ${{ matrix.service-path }})" >> $GITHUB_OUTPUT
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME || (env.REGISTRY == 'ghcr.io' && github.actor) }}
+          password: ${{ secrets.DOCKER_PASSWORD || (env.REGISTRY == 'ghcr.io' && secrets.GITHUB_TOKEN) }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/draft-${{ steps.info.outputs.domain}}-${{ steps.info.outputs.service }}
+          tags: |
+            type=sha
+            type=edge,branch=main
+            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='America/Chicago'}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.TARGET_PLATFORMS }}
+          build-args: |
+            DOMAIN=${{ steps.info.outputs.domain}}
+            SERVICE=${{ steps.info.outputs.service}}

--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -16,64 +16,63 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # changed:
-  #   name: Prepare
-  #   uses: ./.github/workflows/changes.yml
-  #   with:
-  #     path: services
-  #     dir_names_max_depth: 2
+  changed:
+    name: Prepare
+    uses: ./.github/workflows/changes.yml
+    with:
+      path: services
+      dir_names_max_depth: 2
 
-  # build-and-test:
-  #   name: Build-Test (${{ matrix.service-path }})
-  #   # needs: [changed]
-  #   runs-on: ubuntu-latest
-  #   # if: needs.changed.outputs.any_changed == 'true'
-  #   strategy:
-  #     matrix:
-  #       go-version: ['1.21.x']
-  #       # service-path: ${{ fromJSON(needs.changed.outputs.matrix) }}
-  #       service-path: [ 'examples/crud', 'examples/echo']
-  #   steps:
-  #     - uses: actions/checkout@v4
-
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 18
-  #         cache-dependency-path: services/${{ matrix.service-path }}/web-client/package-lock.json
-
-  #     - name: Install Node dependencies
-  #       run: |
-  #         cd services/${{ matrix.service-path }}/web-client &&
-  #         npm i -D @swc/cli @swc/core &&
-  #         npm install
-
-  #     - name: Build web-client
-  #       run: |
-  #         cd services/${{ matrix.service-path }}/web-client &&
-  #         npm run build
-
-  #     - uses: actions/setup-go@v5
-  #       with:
-  #         go-version: ${{ matrix.go-version }}
-  #         cache-dependency-path: services/${{ matrix.service-path }}/go.sum
-
-  #     - name: Test
-  #       working-directory: services/${{ matrix.service-path }}
-  #       run: go test ./...
-
-  #     - name: Build
-  #       working-directory: services/${{ matrix.service-path }}
-  #       run: go build main.go
-
-  docker-image:
-    name: Docker Image (${{ matrix.service-path }})
+  build-and-test:
+    name: Build-Test (${{ matrix.service-path }})
     # needs: [changed]
     runs-on: ubuntu-latest
     # if: needs.changed.outputs.any_changed == 'true'
     strategy:
       matrix:
+        go-version: ['1.21.x']
         # service-path: ${{ fromJSON(needs.changed.outputs.matrix) }}
         service-path: [ 'examples/crud', 'examples/echo']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache-dependency-path: services/${{ matrix.service-path }}/web-client/package-lock.json
+
+      - name: Install Node dependencies
+        run: |
+          cd services/${{ matrix.service-path }}/web-client &&
+          npm i -D @swc/cli @swc/core &&
+          npm install
+
+      - name: Build web-client
+        run: |
+          cd services/${{ matrix.service-path }}/web-client &&
+          npm run build
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: services/${{ matrix.service-path }}/go.sum
+
+      - name: Test
+        working-directory: services/${{ matrix.service-path }}
+        run: go test ./...
+
+      - name: Build
+        working-directory: services/${{ matrix.service-path }}
+        run: go build main.go
+
+  docker-image:
+    name: Docker Image (${{ matrix.service-path }})
+    needs: [changed]
+    runs-on: ubuntu-latest
+    if: needs.changed.outputs.any_changed == 'true'
+    strategy:
+      matrix:
+        service-path: ${{ fromJSON(needs.changed.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -111,7 +110,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.TARGET_PLATFORMS }}

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - services/**
 
+env:
+  REGISTRY: ${{ vars.REGISTRY || 'ghcr.io' }}
+  TARGET_PLATFORMS: linux/amd64,linux/arm64
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.TARGET_PLATFORMS }}

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -96,7 +96,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/draft-${{ steps.info.outputs.domain}}-${{ steps.info.outputs.service }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-${{ steps.info.outputs.domain}}-${{ steps.info.outputs.service }}
           tags: |
             type=sha
 

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -63,3 +63,55 @@ jobs:
       - name: Build
         working-directory: services/${{ matrix.service-path }}
         run: go build main.go
+
+  docker-image:
+    name: Docker Image (${{ matrix.service-path }})
+    needs: [changed]
+    runs-on: ubuntu-latest
+    if: needs.changed.outputs.any_changed == 'true'
+    strategy:
+      matrix:
+        service-path: ${{ fromJSON(needs.changed.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract service info
+        id: info
+        run: |
+          echo "domain=$(dirname ${{ matrix.service-path }})" >> $GITHUB_OUTPUT
+          echo "service=$(basename ${{ matrix.service-path }})" >> $GITHUB_OUTPUT
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME || (env.REGISTRY == 'ghcr.io' && github.actor) }}
+          password: ${{ secrets.DOCKER_PASSWORD || (env.REGISTRY == 'ghcr.io' && secrets.GITHUB_TOKEN) }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/draft-${{ steps.info.outputs.domain}}-${{ steps.info.outputs.service }}
+          tags: |
+            type=sha
+            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='America/Chicago'}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.TARGET_PLATFORMS }}
+          build-args: |
+            DOMAIN=${{ steps.info.outputs.domain}}
+            SERVICE=${{ steps.info.outputs.service}}

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -99,7 +99,6 @@ jobs:
           images: ${{ env.REGISTRY }}/draft-${{ steps.info.outputs.domain}}-${{ steps.info.outputs.service }}
           tags: |
             type=sha
-            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='America/Chicago'}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-services/blueprint/web-client/target
 pipelines/secrets
 
 node_1
@@ -6,9 +5,10 @@ node_2
 node_3
 
 .DS_Store
-node_modules/
 
 __debug_*
 
-target/
+node_modules
+dist
+target
 main

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG GO_VERSION=1.21.3
 ARG ALPINE_VERSION=3.18
 
 # Build web client (if needed)
-FROM node:18 as web-client-builder
+FROM node:18 AS web-client-builder
 WORKDIR /web
 RUN npm i -D @swc/cli @swc/core
 RUN rm package*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,31 @@
 ARG GO_VERSION=1.21.3
 ARG ALPINE_VERSION=3.18
 
-# This layer builds the binary
-FROM golang:${GO_VERSION}-alpine AS builder
+# Build web client (if needed)
+FROM node:18 as web-client-builder
+WORKDIR /web
+RUN npm i -D @swc/cli @swc/core
+RUN rm package*.json
 
-# Install build dependencies
+ARG DOMAIN
+ARG SERVICE
+
+# Install node modules
+COPY ./services/${DOMAIN}/${SERVICE}/web-client/package*.json .
+RUN npm install
+
+# Build dist
+COPY ./services/${DOMAIN}/${SERVICE}/web-client .
+RUN npm run build
+
+# Make sure dist directory exists even if there's no client to build
+RUN mkdir -p ./dist
+
+# Build final binary
+FROM golang:${GO_VERSION}-alpine AS go-builder
+WORKDIR /app
 RUN apk add --no-cache git upx
 
-# Project setup
-WORKDIR /app
-
-# Build arguments
 ARG DOMAIN
 ARG SERVICE
 
@@ -20,16 +35,17 @@ COPY ./services/${DOMAIN}/${SERVICE}/go.sum ./go.sum
 
 # Fetch go modules
 RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
+go mod download
 RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod verify
+go mod verify
 
 # Copy over code
 COPY ./services/${DOMAIN}/${SERVICE} .
+COPY --from=web-client-builder /web/dist ./web-client/dist
 
 # Run tests
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-    go test -race -test.v ./...
+    go test -test.v ./...
 
 # Build the binary
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
@@ -38,14 +54,14 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 # Compress the binary
 RUN upx main
 
-# This layer runs the binary
+# Final image
 FROM alpine:${ALPINE_VERSION} AS runner
 
 # Install dependencies
 RUN apk add -U --no-cache ca-certificates
 
-# Copy the binary from builder
-COPY --from=builder /app/main /etc/main
+# Copy the binary from go-builder
+COPY --from=go-builder /app/main /etc/main
 
 # Set context to run main
 WORKDIR /etc

--- a/services/examples/crud/web-client/package.json
+++ b/services/examples/crud/web-client/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "placeholder",
+  "scripts": {
+    "build": ""
+  }
+}

--- a/services/examples/echo/web-client/package.json
+++ b/services/examples/echo/web-client/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "placeholder",
+  "scripts": {
+    "build": ""
+  }
+}


### PR DESCRIPTION
Several changes to enable Docker builds for all services:
- Added a web-client build stage to the Dockerfile
- Added dummy `package.json` files to services without web-clients (I don't like this workaround but it's fine for now)
- Updated ignore files
- Added Docker steps to the services CI workflow
- Added a CD workflow for services