### PR TITLE
feat: non-TLS HTTP2 support

### DIFF
--- a/pkg/chassis/builder.go
+++ b/pkg/chassis/builder.go
@@ -185,7 +185,7 @@ func (c *Runtime) synchronize(pid *sdv1.ProcessIdentity) {
 // them on a background goroutine
 func (c *Runtime) Start() {
 	cors := c.buildCors()
-	handler := cors.Handler(c.mux)
+	handler := h2c.NewHandler(cors.Handler(c.mux), &http2.Server{})
 	if c.mux == nil {
 		c.mux = http.NewServeMux()
 	}


### PR DESCRIPTION
By wrapping the HTTP handler with the h2c package we can use HTTP2 calls without TLS. Otherwise you get some funky errors like `unknown: HTTP status 505 HTTP Version Not Supported` from ConnectRPC.