### PR TITLE
fix: `dctl` improvements

### DIFF
--- a/tools/dctl/cmd/api/build.go
+++ b/tools/dctl/cmd/api/build.go
@@ -38,6 +38,7 @@ func Build(cmd *cobra.Command, args []string) (err error) {
 		WorkingDir: "/workspace",
 	}
 	hostConfig := &container.HostConfig{
+		AutoRemove: true,
 		Mounts: []mount.Mount{
 			{
 				Type:   mount.TypeBind,
@@ -50,7 +51,7 @@ func Build(cmd *cobra.Command, args []string) (err error) {
 	// mod update
 	output.Println("Running `buf dep update`...")
 	config.Cmd = []string{"buf", "dep", "update"}
-	err = dctl.RunContainer(ctx, project.API.ContainerName, config, hostConfig, true, true)
+	err = dctl.RunContainer(ctx, dctl.GenerateContainerName(), config, hostConfig, true)
 	if err != nil {
 		return err
 	}
@@ -58,7 +59,7 @@ func Build(cmd *cobra.Command, args []string) (err error) {
 	// generate go
 	output.Println("Generating Go protos...")
 	config.Cmd = []string{"buf", "generate", "--template", "buf.gen.go.yaml"}
-	err = dctl.RunContainer(ctx, project.API.ContainerName, config, hostConfig, true, true)
+	err = dctl.RunContainer(ctx, dctl.GenerateContainerName(), config, hostConfig, true)
 	if err != nil {
 		return err
 	}
@@ -66,7 +67,7 @@ func Build(cmd *cobra.Command, args []string) (err error) {
 	// generate gotag
 	output.Println("Generating Gotag protos...")
 	config.Cmd = []string{"buf", "generate", "--template", "buf.gen.gotag.yaml"}
-	err = dctl.RunContainer(ctx, project.API.ContainerName, config, hostConfig, true, true)
+	err = dctl.RunContainer(ctx, dctl.GenerateContainerName(), config, hostConfig, true)
 	if err != nil {
 		return err
 	}
@@ -74,7 +75,7 @@ func Build(cmd *cobra.Command, args []string) (err error) {
 	// generate web
 	output.Println("Generating Web protos...")
 	config.Cmd = []string{"npx", "buf", "generate", "--template", "buf.gen.web.yaml"}
-	err = dctl.RunContainer(ctx, project.API.ContainerName, config, hostConfig, true, true)
+	err = dctl.RunContainer(ctx, dctl.GenerateContainerName(), config, hostConfig, true)
 	if err != nil {
 		return err
 	}
@@ -94,7 +95,7 @@ func Build(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 	config.Cmd = []string{"chown", "-R", fmt.Sprintf("%s:%s", u.Uid, u.Gid), "/workspace"}
-	err = dctl.RunContainer(ctx, project.API.ContainerName, config, hostConfig, true, true)
+	err = dctl.RunContainer(ctx, dctl.GenerateContainerName(), config, hostConfig, true)
 	if err != nil {
 		return err
 	}

--- a/tools/dctl/cmd/api/init.go
+++ b/tools/dctl/cmd/api/init.go
@@ -47,6 +47,14 @@ func Init(cmd *cobra.Command, args []string) error {
 		},
 	}
 
+	// initialize go module
+	output.Println("Initializing go module...")
+	config.Cmd = []string{"go", "mod", "init", fmt.Sprintf("%s/api", project.Repo)}
+	err = dctl.RunContainer(ctx, dctl.GenerateContainerName(), config, hostConfig, true)
+	if err != nil {
+		return err
+	}
+
 	// install node modules
 	output.Println("Installing node modules...")
 	config.Cmd = []string{"npm", "install", "--no-fund"}

--- a/tools/dctl/cmd/api/init.go
+++ b/tools/dctl/cmd/api/init.go
@@ -38,6 +38,7 @@ func Init(cmd *cobra.Command, args []string) error {
 		WorkingDir: "/workspace",
 	}
 	hostConfig := &container.HostConfig{
+		AutoRemove: true,
 		Mounts: []mount.Mount{
 			{
 				Type:   mount.TypeBind,
@@ -58,7 +59,7 @@ func Init(cmd *cobra.Command, args []string) error {
 	// install node modules
 	output.Println("Installing node modules...")
 	config.Cmd = []string{"npm", "install", "--no-fund"}
-	err = dctl.RunContainer(ctx, project.API.ContainerName, config, hostConfig, true, true)
+	err = dctl.RunContainer(ctx, dctl.GenerateContainerName(), config, hostConfig, true)
 	if err != nil {
 		return err
 	}
@@ -70,7 +71,7 @@ func Init(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	config.Cmd = []string{"chown", "-R", fmt.Sprintf("%s:%s", u.Uid, u.Gid), "/workspace"}
-	err = dctl.RunContainer(ctx, project.API.ContainerName, config, hostConfig, true, true)
+	err = dctl.RunContainer(ctx, dctl.GenerateContainerName(), config, hostConfig, true)
 	if err != nil {
 		return err
 	}

--- a/tools/dctl/cmd/project/template/api/buf.gen.go.yaml
+++ b/tools/dctl/cmd/project/template/api/buf.gen.go.yaml
@@ -1,18 +1,18 @@
 version: v1
 plugins:
-  # google.golang.org/protobuf/cmd/protoc-gen-go@latest
+  # go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
   - name: go
-    out: gen/go
+    out: .
     opt:
       - paths=source_relative
-  # connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
+  # go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
   - plugin: connect-go
-    out: gen/go
+    out: .
     opt:
       - paths=source_relative
-  # github.com/envoyproxy/protoc-gen-validate
+  # go install github.com/envoyproxy/protoc-gen-validate
   - name: validate
-    out: gen/go
+    out: .
     opt:
       - paths=source_relative
       - lang=go

--- a/tools/dctl/cmd/project/template/api/buf.gen.gotag.yaml
+++ b/tools/dctl/cmd/project/template/api/buf.gen.gotag.yaml
@@ -1,10 +1,10 @@
 version: v1
 plugins:
-  # github.com/srikrsna/protoc-gen-gotag
+  # go isntall github.com/srikrsna/protoc-gen-gotag
   - name: gotag
     out: .
     opt:
-      - outdir=gen/go
+      - outdir=.
       - paths=source_relative
       - xxx=pg+"-" bun+"-" json+"-" yaml+"-" csv+"-"
       - auto=pg-as-lower_snake+bun-as-lower_snake+yaml-as-lower_snake+csv-as-lower_snake+json-as-lower_snake

--- a/tools/dctl/cmd/project/template/api/buf.gen.web.yaml
+++ b/tools/dctl/cmd/project/template/api/buf.gen.web.yaml
@@ -1,24 +1,24 @@
 version: v1
 plugins:
   - plugin: es
-    out: gen/web
+    out: .
     opt:
       - target=ts
   - plugin: es
-    out: gen/web
+    out: .
     opt:
       - target=js
   - plugin: connect-es
-    out: gen/web
+    out: .
     opt:
       - target=ts
   - plugin: connect-es
-    out: gen/web
+    out: .
     opt:
       - target=js
   - name: connect-query
-    out: gen/web
+    out: .
     opt: target=ts
   - name: connect-query
-    out: gen/web
+    out: .
     opt: target=js

--- a/tools/dctl/go.mod
+++ b/tools/dctl/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/docker/docker v25.0.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
+	github.com/google/uuid v1.4.0
 	github.com/moby/term v0.5.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2

--- a/tools/dctl/go.sum
+++ b/tools/dctl/go.sum
@@ -48,6 +48,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=


### PR DESCRIPTION
A few small fixes in this one:
- Added back the initialization of the `api/go.mod` file using the current project's git URL. This was accidentally dropped in a previous refactor.
- Fixed the templated `api/*.yaml` files to generate files alongside the `.proto` files
- Fixed an issue where during `dctl api` commands Docker containers could fail and not be removed causing subsequent commands to fail until the user manually removed the old container (since each run reused the same image name). Now all `dctl api` commands use generated container names and rely on the Docker API to clean up old containers even after a failure.