### PR TITLE
feat: Blueprint custom badger path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ pipelines/secrets
 node_1
 node_2
 node_3
+tmp
 
 .DS_Store
 

--- a/services/core/blueprint/config.yaml
+++ b/services/core/blueprint/config.yaml
@@ -4,6 +4,9 @@ service:
   network:
     port: 2221
 
+badger:
+  path: tmp/
+
 raft:
   node-id: node_1
   address: localhost

--- a/services/core/blueprint/go.mod
+++ b/services/core/blueprint/go.mod
@@ -6,6 +6,8 @@ go 1.21.3
 
 // replace github.com/steady-bytes/draft/pkg/chassis => ../../../pkg/chassis
 
+// replace github.com/steady-bytes/draft/pkg/repositories => ../../../pkg/repositories
+
 require (
 	connectrpc.com/connect v1.16.2
 	github.com/dgraph-io/badger/v2 v2.2007.4
@@ -14,7 +16,7 @@ require (
 	github.com/steady-bytes/draft/api v0.3.1
 	github.com/steady-bytes/draft/pkg/chassis v0.3.0
 	github.com/steady-bytes/draft/pkg/loggers v0.2.0
-	github.com/steady-bytes/draft/pkg/repositories v0.0.2
+	github.com/steady-bytes/draft/pkg/repositories v0.0.3
 	google.golang.org/protobuf v1.34.2
 )
 

--- a/services/core/blueprint/go.sum
+++ b/services/core/blueprint/go.sum
@@ -202,8 +202,8 @@ github.com/steady-bytes/draft/pkg/chassis v0.3.0 h1:9uk+RRuSec2Sl7wy5ZSNv3IcqRqb
 github.com/steady-bytes/draft/pkg/chassis v0.3.0/go.mod h1:5TQfgltb/008bcuLe6vAQva0Kzrq1zEDCFoCfQjzzLo=
 github.com/steady-bytes/draft/pkg/loggers v0.2.0 h1:d1a3l6HMfa8g9+o+roeT5BoA7aeDBIh6UMLeOddsNsk=
 github.com/steady-bytes/draft/pkg/loggers v0.2.0/go.mod h1:nXeOQ6lXhsVWHzRqVcJz0JIeSW75ORVN+0izJwwnH+Y=
-github.com/steady-bytes/draft/pkg/repositories v0.0.2 h1:vtcJowGB0VxYDd/1Zs5zYPIPTqvoh0C53kibnOtrZuM=
-github.com/steady-bytes/draft/pkg/repositories v0.0.2/go.mod h1:JQ4wYAwaJQKDwKaG+9bdSIIzOuroIqNzVsIx9JX99H4=
+github.com/steady-bytes/draft/pkg/repositories v0.0.3 h1:6MyBkga27olqM42HriZZJgbyvrwSwyZDHtrkdSKMNPA=
+github.com/steady-bytes/draft/pkg/repositories v0.0.3/go.mod h1:JQ4wYAwaJQKDwKaG+9bdSIIzOuroIqNzVsIx9JX99H4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
Upgrading `pkg/repositories` so that Blueprint can take a custom `badger.path` and use a PVC in Kubernetes.