### PR TITLE
feat: add `dctl release image` command

### DIFF
--- a/tools/dctl/cmd/release.go
+++ b/tools/dctl/cmd/release.go
@@ -23,10 +23,25 @@ a git tag with the new version and push it to the git origin.`,
 	RunE:    release.Module,
 }
 
+var releaseImage = &cobra.Command{
+	Use:     "image",
+	Aliases: []string{"img"},
+	Short:   "Release a Docker image",
+	Long: `Release a Docker image by adding a tag to an existing image (e.g. latest, edge). This will pull the existing image,
+apply the new tag, and then push the image. You must set the env variables CONTAINER_REGISTRY_USERNAME and CONTAINER_REGISTRY_PASSWORD
+in order to authenticate to the registry.`,
+	Example: "dctl release image --image registry.com/hello/world --source latest --target v1.0.0",
+	RunE:    release.Image,
+}
+
 func init() {
 	// add parent
 	rootCmd.AddCommand(releaseCmd)
 	// add children
 	releaseCmd.AddCommand(releaseModule)
 	releaseModule.Flags().StringVarP(&release.Path, "path", "p", "", "path of Go module to release (e.g. pkg/chassis or tools/dctl)")
+	releaseCmd.AddCommand(releaseImage)
+	releaseImage.Flags().StringVarP(&release.ImageName, "image", "i", "", "the Docker image to release/tag")
+	releaseImage.Flags().StringVarP(&release.SourceTag, "source", "s", "", "the source image tag to pull")
+	releaseImage.Flags().StringVarP(&release.TargetTag, "target", "t", "", "the target image tag to apply and push")
 }

--- a/tools/dctl/cmd/release/image.go
+++ b/tools/dctl/cmd/release/image.go
@@ -1,0 +1,48 @@
+package release
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/steady-bytes/draft/tools/dctl/docker"
+)
+
+var (
+	ImageName string
+	SourceTag    string
+	TargetTag    string
+)
+
+func Image(cmd *cobra.Command, args []string) (err error) {
+	ctx := cmd.Context()
+
+	dockerCtl, err := docker.NewDockerController()
+	if err != nil {
+		return err
+	}
+
+	if ImageName == "" {
+		return fmt.Errorf("image name is required")
+	}
+
+	if TargetTag == "" {
+		return fmt.Errorf("tag is required")
+	}
+
+	err = dockerCtl.PullImage(ctx, fmt.Sprintf("%s:%s", ImageName, SourceTag))
+	if err != nil {
+		return err
+	}
+
+	err = dockerCtl.TagImage(ctx, ImageName, SourceTag, TargetTag)
+	if err != nil {
+		return err
+	}
+
+	err = dockerCtl.PushImage(ctx, fmt.Sprintf("%s:%s", ImageName, TargetTag))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tools/dctl/docs/dctl_release.md
+++ b/tools/dctl/docs/dctl_release.md
@@ -18,5 +18,6 @@ Commands for releasing Draft components
 ### SEE ALSO
 
 * [dctl](dctl.md)	 - dctl (Draft Controller) is the built-in CLI for managing everything in Draft
+* [dctl release image](dctl_release_image.md)	 - Release a Docker image
 * [dctl release module](dctl_release_module.md)	 - Release a Go module
 

--- a/tools/dctl/docs/dctl_release_image.md
+++ b/tools/dctl/docs/dctl_release_image.md
@@ -1,0 +1,40 @@
+## dctl release image
+
+Release a Docker image
+
+### Synopsis
+
+Release a Docker image by adding a tag to an existing image (e.g. latest, edge). This will pull the existing image,
+apply the new tag, and then push the image. You must set the env variables CONTAINER_REGISTRY_USERNAME and CONTAINER_REGISTRY_PASSWORD
+in order to authenticate to the registry.
+
+```
+dctl release image [flags]
+```
+
+### Examples
+
+```
+dctl release image --image registry.com/hello/world --source latest --target v1.0.0
+```
+
+### Options
+
+```
+  -h, --help            help for image
+  -i, --image string    the Docker image to release/tag
+  -s, --source string   the source image tag to pull
+  -t, --target string   the target image tag to apply and push
+```
+
+### Options inherited from parent commands
+
+```
+      --config string    config file
+      --context string   override the current context
+```
+
+### SEE ALSO
+
+* [dctl release](dctl_release.md)	 - Commands for releasing Draft components
+


### PR DESCRIPTION
Adds a `dctl release image` command which pulls an image with a source tag and then pushes a new target tag.