### PR TITLE
fix: serving SPAs

### DIFF
--- a/pkg/chassis/client_application.go
+++ b/pkg/chassis/client_application.go
@@ -4,7 +4,66 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"os"
+	"path"
+	"strings"
 )
+
+const (
+	webClientRoot = "web-client/dist"
+)
+
+// NOTE: the logic for serving a SPA is modified from the example here: https://github.com/gorilla/mux#serving-single-page-applications
+
+// spaHandler implements the http.Handler interface, so we can use it
+// to respond to HTTP requests. The path to the index file within the embedded
+// file system is used to serve the SPA.
+type spaHandler struct {
+	indexPath  string
+	fileSystem fs.FS
+}
+
+// ServeHTTP inspects the URL path to locate a file within the file system
+// on the SPA handler. If a file is found, it will be served. If not, the
+// file located at the index path on the SPA handler will be served. This
+// is suitable behavior for serving an SPA (single page application).
+func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	// clean and trim path (default to index)
+	path := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
+	if path == "" {
+		path = h.indexPath
+	}
+
+	// check whether a file exists or is a directory at the given path
+	f, err := h.fileSystem.Open(path)
+	if os.IsNotExist(err) {
+		// file does not exist, serve index.html
+		http.ServeFileFS(w, r, h.fileSystem, h.indexPath)
+		return
+	}
+	if err != nil {
+		// if we got an error (that wasn't that the file doesn't exist) opening the
+		// file, return a 500 internal server error and stop
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		// if we got an error stating the file, return a 500 internal server error and stop
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if fi.IsDir() {
+		// if path is a directory, serve index.html
+		http.ServeFileFS(w, r, h.fileSystem, h.indexPath)
+		return
+	}
+
+	// otherwise, serve without modification
+	http.ServeFileFS(w, r, h.fileSystem, path)
+}
 
 func (c *Runtime) withClientApplication(e embed.FS) {
 	// Init and store the http multiplexer
@@ -12,14 +71,17 @@ func (c *Runtime) withClientApplication(e embed.FS) {
 		c.mux = http.NewServeMux()
 	}
 
-	c.mux.Handle("/", http.FileServer(c.getFileSystem(e)))
+	spa := spaHandler{
+		indexPath:  "index.html",
+		fileSystem: c.getFileSystem(e),
+	}
+	c.mux.Handle("/", spa)
 }
 
-func (c *Runtime) getFileSystem(e embed.FS) http.FileSystem {
-	fsys, err := fs.Sub(e, "web-client/dist")
+func (c *Runtime) getFileSystem(e embed.FS) fs.FS {
+	fsys, err := fs.Sub(e, webClientRoot)
 	if err != nil {
 		panic(err)
 	}
-
-	return http.FS(fsys)
+	return fs.FS(fsys)
 }

--- a/pkg/chassis/go.mod
+++ b/pkg/chassis/go.mod
@@ -1,6 +1,6 @@
 module github.com/steady-bytes/draft/pkg/chassis
 
-go 1.21.3
+go 1.22.5
 
 // replace github.com/steady-bytes/draft/api => ../../api
 


### PR DESCRIPTION
Fixed the routing issues with serving single page applications (SPAs). This change using the examples from [gorilla/mux](https://github.com/gorilla/mux#serving-single-page-applications) and modified them for using an embedded filesystem and the stdlib mux server.

Also bumped go to 1.22.5 on `pkg/chassis` so that I could have access to the `http.ServeFileFS()` method.