### PR TITLE
fix: rpc streams

### DIFF
--- a/services/core/fuse/control_plane/controller.go
+++ b/services/core/fuse/control_plane/controller.go
@@ -330,6 +330,8 @@ func makeRouterConfig(routes map[string]*anypb.Any) *route.RouteConfiguration {
 						ClusterSpecifier: &route.RouteAction_Cluster{
 							Cluster: clusterName(r),
 						},
+						// disable with 0 value
+						Timeout: &durationpb.Duration{},
 					},
 				},
 				TypedPerFilterConfig: map[string]*anypb.Any{},

--- a/services/core/fuse/control_plane/controller.go
+++ b/services/core/fuse/control_plane/controller.go
@@ -211,6 +211,8 @@ func (cp *controlPlane) apply(ctx context.Context, client kvv1Connect.KeyValueSe
 				UpgradeType: "websocket",
 			},
 		},
+		// disable with 0 value
+		StreamIdleTimeout: &durationpb.Duration{},
 	}
 
 	pbst, err := anypb.New(manager)


### PR DESCRIPTION
Fix RPC streams dropping after about 15 seconds due to Envoy timing out the connections. This PR disables timeouts entirely though we might want to make this configurable on the route level through the Fuse API later.