### PR TITLE
feat: test env for loggers

### DIFF
--- a/pkg/loggers/logrus/logrus.go
+++ b/pkg/loggers/logrus/logrus.go
@@ -40,7 +40,7 @@ func (l *logger) Entry() *logrus.Entry {
 }
 
 func (l *logger) Start(config chassis.Config) {
-	if config.Env() != "local" {
+	if config.Env() != "local" && config.Env() != "test" {
 		logrus.SetFormatter(&Formatter{
 			Line:    true,
 			Package: true,

--- a/pkg/loggers/zerolog/zerolog.go
+++ b/pkg/loggers/zerolog/zerolog.go
@@ -45,7 +45,7 @@ func (l *logger) Logger() zerolog.Logger {
 
 func (l *logger) Start(config chassis.Config) {
 	zl := zerolog.New(os.Stdout).With().Str("service", config.Name()).Timestamp().Logger()
-	if config.Env() == "local" {
+	if config.Env() == "local" || config.Env() == "test" {
 		zl = zl.Output(zerolog.ConsoleWriter{Out: os.Stdout})
 	}
 	l.level = chassis.ParseLogLevel(config.GetString("service.logging.level"))


### PR DESCRIPTION
Log as plain text (not JSON) when the draft env is "test" as well as "local".