### PR TITLE
fix: Concurrent map writes in Zerolog `WithField()`

### DIFF
--- a/pkg/loggers/zerolog/zerolog.go
+++ b/pkg/loggers/zerolog/zerolog.go
@@ -79,20 +79,21 @@ func (l *logger) WithContext(ctx context.Context) chassis.Logger {
 }
 
 func (l *logger) WithField(key string, value any) chassis.Logger {
-	str := fmt.Sprintf("%v", value)
-	l.fields[key] = str
-	return &logger{
-		logger: l.logger.With().Str(key, str).Logger(),
-		fields: l.fields,
-		level:  l.level,
-	}
+	return l.WithFields(chassis.Fields{key: value})
 }
 
 func (l *logger) WithFields(fields chassis.Fields) chassis.Logger {
+	newFields := make(chassis.Fields, len(l.fields)+len(fields))
+	// copy old fields
+	for k, v := range l.fields {
+		newFields[k] = v
+	}
+	// copy old logger
 	new := &logger{
 		logger: l.logger.With().Logger(),
-		fields: l.fields,
+		fields: newFields,
 	}
+	// append new fields
 	for key, value := range fields {
 		str := fmt.Sprintf("%v", value)
 		new.fields[key] = str


### PR DESCRIPTION
This fixes an issue where you could hit concurrent map writes if two goroutines called `.WithField` or `.WithFields` on the logger at the same time. This PR deep copies the fields attribute of the logger before modifying to prevent this.