### PR TITLE
fix: remove blocking mutex on `SetAndWrite()`

### DIFF
--- a/pkg/chassis/config.go
+++ b/pkg/chassis/config.go
@@ -139,8 +139,6 @@ func (c *config) SetDefault(key string, value any) {
 }
 
 func (c *config) SetAndWrite(key string, value any) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.Set(key, value)
 	return c.WriteConfig()
 }


### PR DESCRIPTION
Removed a redundant lock which was causing a perpetual lock when calling `SetAndWrite()`. Both `Set()` and `WriteConfig()` have their own mutex management so this was redundant anyway.