### PR TITLE
fix: chassis networking improvements

### DIFF
--- a/pkg/chassis/config.go
+++ b/pkg/chassis/config.go
@@ -88,9 +88,8 @@ func LoadConfig() Config {
 }
 
 func setDefaults(v *viper.Viper) {
-	v.SetDefault("service.network.port", 8090)
-	v.SetDefault("service.network.bind_address", "0.0.0.0")
-	v.SetDefault("service.network.advertise_address", "127.0.0.1")
+	v.SetDefault("service.network.bind_address", "localhost")
+	v.SetDefault("service.network.bind_port", 8090)
 	v.SetDefault("service.env", "local")
 	v.SetDefault("service.logging.level", "info")
 }

--- a/pkg/chassis/consensus.go
+++ b/pkg/chassis/consensus.go
@@ -81,7 +81,7 @@ func (c *Runtime) bootstrapRaft(registrar ConsensusRegistrar) {
 		for leader := range notifyCh {
 			registrar.LeadershipChange(c.logger, leader, url)
 		}
-	}(raftScheme, raftHost, c.config.GetString("service.network.port"))
+	}(raftScheme, raftHost, c.config.GetString("service.network.bind_port"))
 
 	// configuration for raft
 	if raftPort == "" || raftNodeID == "" {

--- a/pkg/chassis/consensus_controller.go
+++ b/pkg/chassis/consensus_controller.go
@@ -3,7 +3,6 @@ package chassis
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/hashicorp/raft"
 )
@@ -29,19 +28,16 @@ func NewRaftController(r *raft.Raft) RaftController {
 
 func (c *raftController) Join(ctx context.Context, nodeID, raftAddress string) error {
 	if c.raft.State() != raft.Leader {
-		fmt.Println("must join leader")
 		return errors.New("must join leader")
 	}
 
 	config := c.raft.GetConfiguration()
 	if err := config.Error(); err != nil {
-		fmt.Println("failed to get configuration")
 		return errors.New("failed to get configuration")
 	}
 
 	index := c.raft.AddVoter(raft.ServerID(nodeID), raft.ServerAddress(raftAddress), 0, 0)
 	if index.Error() != nil {
-		fmt.Println("failed to add new voter", index.Error())
 		return errors.New("failed to add new voter")
 	}
 

--- a/pkg/chassis/runtime.go
+++ b/pkg/chassis/runtime.go
@@ -3,7 +3,10 @@ package chassis
 import (
 	"net"
 	"net/http"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	sdv1 "github.com/steady-bytes/draft/api/core/registry/service_discovery/v1"
 	sdv1Cnt "github.com/steady-bytes/draft/api/core/registry/service_discovery/v1/v1connect"
@@ -51,6 +54,10 @@ func (b *BlueprintCluster) Pop() *sdv1.Node {
 }
 
 func New(logger Logger) *Runtime {
+	// set up closer channel to handle graceful shutdown
+	closer = make(chan os.Signal, 1)
+	signal.Notify(closer, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
 	if logger == nil {
 		panic("logger cannot be nil")
 	}


### PR DESCRIPTION
This PR resolves a few small issues with the chassis and networking:

- Fixes an issue with blueprint reconnects hitting infinite recursions
- Moves to a consistent pattern with `service.network` configs
- Removes/changes some spammy logging
- Addes a proper `closer` channel that can be used to cleanly shutdown when an unrecoverable situation is encountered