### PR TITLE
feat: Allow empty host on `WithRoute`

### DIFF
--- a/pkg/chassis/networking.go
+++ b/pkg/chassis/networking.go
@@ -76,12 +76,6 @@ func (c *Runtime) setAndValidateRoute(route *ntv1.Route) *ntv1.Route {
 	if route.Match == nil {
 		c.logger.Panic("route requested but no match provided")
 	}
-	if route.Match.Host == "" {
-		route.Match.Host = c.config.GetString("service.network.external.host")
-	}
-	if route.Match.Host == "" {
-		c.logger.Panic("route requested but no host provided in the match")
-	}
 	if route.Endpoint == nil {
 		route.Endpoint = &ntv1.Endpoint{
 			Host: c.getConfigInternalHost(),

--- a/pkg/repositories/postgres/bun/bun.go
+++ b/pkg/repositories/postgres/bun/bun.go
@@ -44,7 +44,7 @@ func (r *repository) Open(ctx context.Context, config chassis.Config) error {
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(url)))
 	client := bun.NewDB(sqldb, pgdialect.New())
 	r.client = client
-	return nil
+	return r.Ping(ctx)
 }
 
 func (r *repository) Close(ctx context.Context) error {


### PR DESCRIPTION
Envoy requires unique domains for all virtual hosts within the same route configuration. This was causing issues with multiple services registering under the same domain/host through fuse. This PR removes the requirement to specify a host when registering routes and #65 updates fuse to add routes with no defined host to a default virtual host.

Oh and I also added a `Ping()` call to the `repositories/postgres/bun` client's `Open()` so that the database connection is actually verified on boot.