### PR TITLE
feat: dctl improvements

### DIFF
--- a/tools/dctl/cmd/context/import.go
+++ b/tools/dctl/cmd/context/import.go
@@ -1,10 +1,13 @@
 package context
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/steady-bytes/draft/tools/dctl/config"
+	"github.com/steady-bytes/draft/tools/dctl/input"
+	"github.com/steady-bytes/draft/tools/dctl/output"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -22,7 +25,16 @@ func Import(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	dctx := config.LoadWorkspaceContext(filepath.Join(path, "draft.yaml"))
+	f := config.FindWorkspaceFile(path)
+	if f == "" {
+		return errors.New("no draft context found at the given path or in any parent directory")
+	}
+
+	output.Print("Import context from %s? (YES/no)", f)
+	if !input.ConfirmDefaultAllow() {
+		return nil
+	}
+	dctx := config.LoadWorkspaceContext(f)
 
 	// check if a default is set and if not set the new context to the default
 	d := viper.GetString("default")

--- a/tools/dctl/cmd/context/init.go
+++ b/tools/dctl/cmd/context/init.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"embed"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,7 +17,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-const templateDir = "template"
+const (
+	templateDir = "template"
+
+	errNoInput = "no input provided"
+)
 
 var (
 	Path string
@@ -36,10 +41,16 @@ func Init(cmd *cobra.Command, args []string) error {
 	// get name
 	output.Print("What is the name of this context?")
 	name := input.Get()
+	if name == "" {
+		return errors.New(errNoInput)
+	}
 
 	// get repo
 	output.Print("What is the git repository for this context? (e.g. github.com/steady-bytes/draft)")
 	repo := input.Get()
+	if repo == "" {
+		return errors.New(errNoInput)
+	}
 	viper.Set(fmt.Sprintf("contexts.%s.repo", name), repo)
 
 	// confirm path

--- a/tools/dctl/cmd/context/init.go
+++ b/tools/dctl/cmd/context/init.go
@@ -96,6 +96,7 @@ func Init(cmd *cobra.Command, args []string) error {
 
 	// initialize api go module
 	command := exec.Command("go", "mod", "init", fmt.Sprintf("%s/api", repo))
+	command.Dir = filepath.Join(Path, "api")
 	err = execute.ExecuteCommand(ctx, "go", output.Cyan, command)
 	if err != nil {
 		return err

--- a/tools/dctl/cmd/infra.go
+++ b/tools/dctl/cmd/infra.go
@@ -6,6 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	defaultServices = []string{"blueprint", "catalyst", "fuse", "envoy"}
+)
+
 var infraCmd = &cobra.Command{
 	Use:     "infra",
 	Aliases: []string{"infrastructure"},
@@ -28,7 +32,7 @@ var infraCleanCmd = &cobra.Command{
 
 var infraInitCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Pull Docker images required for draft infra",
+	Short: "Pull Docker images required for draft infra and initialize configuration",
 	RunE:  infra.Init,
 }
 
@@ -55,14 +59,14 @@ func init() {
 	rootCmd.AddCommand(infraCmd)
 	// add children
 	infraCmd.AddCommand(infraCleanCmd)
-	infraCleanCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", []string{"nats", "postgres"}, "infra services to act on")
+	infraCleanCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", defaultServices, "infra services to act on")
 	infraCmd.AddCommand(infraInitCmd)
-	infraInitCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", []string{"nats", "postgres"}, "infra services to act on")
+	infraInitCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", defaultServices, "infra services to act on")
 	infraCmd.AddCommand(infraStartCmd)
 	infraStartCmd.Flags().BoolVarP(&infra.Follow, "follow", "f", false, "whether or not to follow the output of the infra docker containers (true/FALSE)")
-	infraStartCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", []string{"nats", "postgres"}, "infra services to act on")
+	infraStartCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", defaultServices, "infra services to act on")
 	infraCmd.AddCommand(infraStopCmd)
-	infraStopCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", []string{"nats", "postgres"}, "infra services to act on")
+	infraStopCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", defaultServices, "infra services to act on")
 	infraCmd.AddCommand(infraStatusCmd)
-	infraStatusCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", []string{"nats", "postgres"}, "infra services to act on")
+	infraStatusCmd.Flags().StringSliceVarP(&infra.Services, "services", "s", defaultServices, "infra services to act on")
 }

--- a/tools/dctl/cmd/infra/clean.go
+++ b/tools/dctl/cmd/infra/clean.go
@@ -1,6 +1,10 @@
 package infra
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/steady-bytes/draft/tools/dctl/docker"
 	"github.com/steady-bytes/draft/tools/dctl/output"
 
@@ -15,9 +19,48 @@ func Clean(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	for _, name := range Services {
+		config, err := getInfraConfig(name)
+		if err != nil {
+			output.Error(err)
+			return err
+		}
+
 		err = dockerCtl.RemoveContainerByName(ctx, containerName(name))
 		if err != nil {
 			output.Error(err)
+		}
+
+		if config.configFile != nil {
+			output.Print("Deleting configuration file for: %s", name)
+			home, err := os.UserHomeDir()
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
+
+			dirName := filepath.Join(home, ".config", "dctl", "infra")
+			fileName := filepath.Join(dirName, fmt.Sprintf("%s.yaml", name))
+			err = os.Remove(fileName)
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
+		}
+
+		if config.mountPoint != nil {
+			output.Print("Deleting volume for: %s", name)
+			home, err := os.UserHomeDir()
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
+
+			dirName := filepath.Join(home, ".config", "dctl", "infra", name)
+			err = os.RemoveAll(dirName)
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/tools/dctl/cmd/infra/configs.go
+++ b/tools/dctl/cmd/infra/configs.go
@@ -2,19 +2,275 @@ package infra
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 )
 
-type infraConfig struct {
-	containerConfig *container.Config
-	hostConfig      *container.HostConfig
-}
+type (
+	infraConfig struct {
+		containerConfig *container.Config
+		hostConfig      *container.HostConfig
+		configFile      *configFile
+		mountPoint      *mountPoint
+	}
+	configFile struct {
+		mountPath string
+		contents  string
+	}
+	mountPoint struct {
+		mountPath string
+	}
+)
 
 var (
 	infraConfigs = map[string]infraConfig{
+		"blueprint": {
+			containerConfig: &container.Config{
+				Image: "ghcr.io/steady-bytes/draft-core-blueprint:latest",
+				ExposedPorts: map[nat.Port]struct{}{
+					"2221/tcp": {},
+					"1111/tcp": {},
+				},
+			},
+			hostConfig: &container.HostConfig{
+				PortBindings: nat.PortMap{
+					"2221/tcp": []nat.PortBinding{
+						{
+							HostIP:   "0.0.0.0",
+							HostPort: "2221",
+						},
+					},
+					"1111/tcp": []nat.PortBinding{
+						{
+							HostIP:   "0.0.0.0",
+							HostPort: "1111",
+						},
+					},
+				},
+			},
+			configFile: &configFile{
+				mountPath: "/etc/config.yaml",
+				contents: `
+service:
+  name: blueprint
+  domain: core
+
+  logging:
+    level: info
+
+  network:
+    bind_address: 0.0.0.0
+    bind_port: 2221
+
+
+badger:
+  path: /etc/badger
+
+raft:
+  node-id: node_1
+  address: localhost
+  port: 1111
+  bootstrap: true
+`,
+			},
+			mountPoint: &mountPoint{
+				mountPath: "/etc/badger",
+			},
+		},
+		"catalyst": {
+			containerConfig: &container.Config{
+				Image: "ghcr.io/steady-bytes/draft-core-catalyst:latest",
+				ExposedPorts: map[nat.Port]struct{}{
+					"2220/tcp": {},
+				},
+			},
+			hostConfig: &container.HostConfig{
+				PortBindings: nat.PortMap{
+					"2220/tcp": []nat.PortBinding{
+						{
+							HostIP:   "0.0.0.0",
+							HostPort: "2220",
+						},
+					},
+				},
+			},
+			configFile: &configFile{
+				mountPath: "/etc/config.yaml",
+				contents: `
+service:
+  name: catalyst
+  domain: core
+  entrypoint: http://draft-blueprint:2221
+
+  logging:
+    level: info
+
+  network:
+    bind_address: 0.0.0.0
+    bind_port: 2220
+    internal:
+      host: localhost
+      port: 2220
+`,
+			},
+		},
+		"fuse": {
+			containerConfig: &container.Config{
+				Image: "ghcr.io/steady-bytes/draft-core-fuse:latest",
+				ExposedPorts: map[nat.Port]struct{}{
+					"18000/tcp": {},
+				},
+			},
+			hostConfig: &container.HostConfig{
+				PortBindings: nat.PortMap{
+					"18000/tcp": []nat.PortBinding{
+						{
+							HostIP:   "0.0.0.0",
+							HostPort: "18000",
+						},
+					},
+				},
+			},
+			configFile: &configFile{
+				mountPath: "/etc/config.yaml",
+				contents: `
+service:
+  name: fuse
+  domain: core
+  entrypoint: http://draft-blueprint:2221
+
+  logging:
+    level: info
+
+  network:
+    bind_address: 0.0.0.0
+    bind_port: 18000
+    internal:
+      host: localhost
+      port: 18000
+
+fuse:
+  address: http://localhost:18000
+  listener:
+    address: 0.0.0.0
+    port: 10000
+`,
+			},
+		},
+		"envoy": {
+			containerConfig: &container.Config{
+				Image: "envoyproxy/envoy:v1.31.2",
+				ExposedPorts: map[nat.Port]struct{}{
+					"10000/tcp": {},
+					"18090/tcp": {},
+				},
+			},
+			hostConfig: &container.HostConfig{
+				PortBindings: nat.PortMap{
+					"10000/tcp": []nat.PortBinding{
+						{
+							HostIP:   "0.0.0.0",
+							HostPort: "10000",
+						},
+					},
+					"19000/tcp": []nat.PortBinding{
+						{
+							HostIP:   "0.0.0.0",
+							HostPort: "19000",
+						},
+					},
+					"18090/tcp": []nat.PortBinding{
+						{
+							HostIP:   "0.0.0.0",
+							HostPort: "18090",
+						},
+					},
+				},
+			},
+			configFile: &configFile{
+				mountPath: "/etc/envoy/envoy.yaml",
+				contents: `
+node:
+  cluster: fuse-proxy
+  id: fuse-proxy-1
+
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 19000
+
+dynamic_resources:
+  cds_config:
+    resource_api_version: V3
+    api_config_source:
+      api_type: GRPC
+      transport_api_version: V3
+      grpc_services:
+        - envoy_grpc:
+            cluster_name: xds_cluster
+      set_node_on_first_message_only: true
+  lds_config:
+    resource_api_version: V3
+    api_config_source:
+      api_type: GRPC
+      transport_api_version: V3
+      grpc_services:
+        - envoy_grpc:
+            cluster_name: xds_cluster
+      set_node_on_first_message_only: true
+
+static_resources:
+  clusters:
+    - name: xds_cluster
+      connect_timeout: 1s
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      # address in which fuse is running on
+                      address: draft-fuse
+                      port_value: 18000
+      http2_protocol_options: {}
+      type: STRICT_DNS
+    - name: als_cluster
+      connect_timeout: 1s
+      load_assignment:
+        cluster_name: als_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 0.0.0.0
+                      port_value: 18090
+      http2_protocol_options: {}
+
+layered_runtime:
+  layers:
+    - name: runtime-0
+      rtds_layer:
+        rtds_config:
+          resource_api_version: V3
+          api_config_source:
+            transport_api_version: V3
+            api_type: GRPC
+            grpc_services:
+              envoy_grpc:
+                cluster_name: xds_cluster
+        name: runtime-0
+`,
+			},
+		},
 		"clickhouse": {
 			containerConfig: &container.Config{
 				Image: "clickhouse/clickhouse-server:23-alpine",
@@ -163,8 +419,8 @@ var (
 			containerConfig: &container.Config{
 				Image: "hasura/graphql-engine:v2.37.0",
 				Env: []string{
-					"HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://draft:draft@host.docker.internal:5432/draft",
-					"HASURA_GRAPHQL_DATABASE_URL=postgres://draft:draft@host.docker.internal:5432/draft",
+					"HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://draft:draft@draft-postgres:5432/draft",
+					"HASURA_GRAPHQL_DATABASE_URL=postgres://draft:draft@draft-postgres:5432/draft",
 					"HASURA_GRAPHQL_ENABLE_CONSOLE=true",
 					"HASURA_GRAPHQL_ENABLED_LOG_TYPES=startup, http-log, webhook-log, websocket-log, query-log",
 					"HASURA_GRAPHQL_ENABLE_TELEMETRY=false",
@@ -178,7 +434,7 @@ var (
 					"8080/tcp": []nat.PortBinding{
 						{
 							HostIP:   "0.0.0.0",
-							HostPort: "8082",
+							HostPort: "8080",
 						},
 					},
 				},
@@ -189,4 +445,45 @@ var (
 
 func containerName(infra string) string {
 	return fmt.Sprintf("draft-%s", infra)
+}
+
+func getInfraConfig(name string) (infraConfig, error) {
+	config, ok := infraConfigs[name]
+	if !ok {
+		return config, fmt.Errorf("invalid infra service name: %s", name)
+	}
+
+	if config.configFile != nil {
+		path, err := configPath()
+		if err != nil {
+			return config, err
+		}
+		config.hostConfig.Binds = []string{
+			fmt.Sprintf("%s:%s", filepath.Join(path, fmt.Sprintf("%s.yaml", name)), config.configFile.mountPath),
+		}
+	}
+
+	if config.mountPoint != nil {
+		path, err := configPath()
+		if err != nil {
+			return config, err
+		}
+		config.hostConfig.Mounts = []mount.Mount{
+			{
+				Type: mount.TypeBind,
+				Source: filepath.Join(path, name),
+				Target: config.mountPoint.mountPath,
+			},
+		}
+	}
+
+	return config, nil
+}
+
+func configPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "dctl", "infra"), nil
 }

--- a/tools/dctl/cmd/infra/init.go
+++ b/tools/dctl/cmd/infra/init.go
@@ -2,6 +2,9 @@ package infra
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/steady-bytes/draft/tools/dctl/docker"
 	"github.com/steady-bytes/draft/tools/dctl/output"
@@ -13,18 +16,64 @@ func Init(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	dockerCtl, err := docker.NewDockerController()
 	if err != nil {
-		return nil
+		return err
+	}
+
+	output.Print("Creating dedicated Docker network")
+	err = dockerCtl.CreateNetwork(ctx, "draft")
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return err
 	}
 
 	for _, name := range Services {
-		config, ok := infraConfigs[name]
-		if !ok {
-			output.Error(fmt.Errorf("invalid infra service name: %s", name))
+		config, err := getInfraConfig(name)
+		if err != nil {
+			output.Error(err)
+			return err
 		}
 		output.Print("Pulling Docker image for: %s", name)
 		err = dockerCtl.PullImage(ctx, config.containerConfig.Image)
 		if err != nil {
 			return err
+		}
+
+		if config.configFile != nil {
+			output.Print("Writing configuration file for: %s", name)
+			home, err := os.UserHomeDir()
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
+
+			dirName := filepath.Join(home, ".config", "dctl", "infra")
+			err = os.Mkdir(dirName, 0777)
+			if err != nil && !os.IsExist(err) {
+				output.Error(err)
+				os.Exit(1)
+			}
+
+			fileName := filepath.Join(dirName, fmt.Sprintf("%s.yaml", name))
+			err = os.WriteFile(fileName, []byte(config.configFile.contents), 0777)
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
+		}
+
+		if config.mountPoint != nil {
+			output.Print("Initializing volume for: %s", name)
+			home, err := os.UserHomeDir()
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
+
+			dirName := filepath.Join(home, ".config", "dctl", "infra", name)
+			err = os.MkdirAll(dirName, 0777)
+			if err != nil && !os.IsExist(err) {
+				output.Error(err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/tools/dctl/cmd/infra/init.go
+++ b/tools/dctl/cmd/infra/init.go
@@ -46,14 +46,14 @@ func Init(cmd *cobra.Command, args []string) error {
 			}
 
 			dirName := filepath.Join(home, ".config", "dctl", "infra")
-			err = os.Mkdir(dirName, 0777)
+			err = os.Mkdir(dirName, 0666)
 			if err != nil && !os.IsExist(err) {
 				output.Error(err)
 				os.Exit(1)
 			}
 
 			fileName := filepath.Join(dirName, fmt.Sprintf("%s.yaml", name))
-			err = os.WriteFile(fileName, []byte(config.configFile.contents), 0777)
+			err = os.WriteFile(fileName, []byte(config.configFile.contents), 0666)
 			if err != nil {
 				output.Error(err)
 				os.Exit(1)
@@ -69,7 +69,7 @@ func Init(cmd *cobra.Command, args []string) error {
 			}
 
 			dirName := filepath.Join(home, ".config", "dctl", "infra", name)
-			err = os.MkdirAll(dirName, 0777)
+			err = os.MkdirAll(dirName, 0666)
 			if err != nil && !os.IsExist(err) {
 				output.Error(err)
 				os.Exit(1)

--- a/tools/dctl/cmd/infra/start.go
+++ b/tools/dctl/cmd/infra/start.go
@@ -2,7 +2,6 @@ package infra
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/steady-bytes/draft/tools/dctl/docker"
@@ -25,9 +24,10 @@ func Start(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	for _, name := range Services {
-		config, ok := infraConfigs[name]
-		if !ok {
-			output.Error(fmt.Errorf("invalid infra service name: %s", name))
+		config, err := getInfraConfig(name)
+		if err != nil {
+			output.Error(err)
+			return err
 		}
 
 		// new context so it doesn't get canceled by the user on ctrl+c if Follow is true

--- a/tools/dctl/cmd/infra/status.go
+++ b/tools/dctl/cmd/infra/status.go
@@ -17,7 +17,7 @@ func Status(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	for name := range infraConfigs {
+	for _, name := range Services {
 		err = checkStatus(ctx, dockerCtl, name, containerName(name))
 		if err != nil {
 			return err

--- a/tools/dctl/config/context.go
+++ b/tools/dctl/config/context.go
@@ -50,7 +50,7 @@ func GetContext() Context {
 		output.Error(err)
 		os.Exit(1)
 	}
-	contextFile := findWorkspaceFile(cwd)
+	contextFile := FindWorkspaceFile(cwd)
 	if contextFile != "" {
 		return LoadWorkspaceContext(contextFile)
 	}
@@ -94,7 +94,7 @@ func LoadWorkspaceContext(path string) Context {
 }
 
 // modified from the go source code: src/cmd/go/internal/modload/init.go
-func findWorkspaceFile(dir string) (root string) {
+func FindWorkspaceFile(dir string) (root string) {
 	if dir == "" {
 		output.Error(fmt.Errorf("dir not set"))
 		return ""

--- a/tools/dctl/execute/exec.go
+++ b/tools/dctl/execute/exec.go
@@ -3,6 +3,7 @@ package execute
 import (
 	"bufio"
 	"context"
+	"os"
 	"os/exec"
 
 	"github.com/steady-bytes/draft/tools/dctl/output"
@@ -39,7 +40,7 @@ func ExecuteCommand(ctx context.Context, name string, c output.Color, cmd *exec.
 	// watch for done signal and kill process if received
 	go func() {
 		<-ctx.Done()
-		err := cmd.Process.Kill()
+		err := cmd.Process.Signal(os.Interrupt)
 		if err != nil {
 			// only error if not closed by user
 			if err.Error() != "signal: killed" && err.Error() != "os: process already finished" {

--- a/tools/dctl/go.mod
+++ b/tools/dctl/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/steady-bytes/draft/api v0.6.0
 	golang.org/x/net v0.23.0
+	golang.org/x/sync v0.5.0
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/tools/dctl/input/prompts.go
+++ b/tools/dctl/input/prompts.go
@@ -40,7 +40,7 @@ func ConfirmDefaultDeny() bool {
 // before calling this method. For example
 //
 //		output.Println("Are you sure you want to do this? (YES/no)")
-//	    if input.ConfirmDefaultAllow() {
+//	    if !input.ConfirmDefaultAllow() {
 //	        return
 //	    }
 //		output.Println("Doing the thing...")


### PR DESCRIPTION
The big change here is adding core draft services to the `infra` commands within dctl. These core services are manged as Docker containers like the other infra services (postgres, nats, etc.). They have been set as the default infra services and all necessary config has been bundled into the dctl binary.

Some smaller improvements are also included:
- Changed to interrupt sub processes instead of killing (so that services can perform clean shutdown)
- Created "draft" Docker network that all infra services are added to
- Initialize the api go module within the `api/` directory during `context init` instead of the root
- Handle no input during `context init`
- Improved `context import` to search parent directories
- Actually write context files during `context init`
