### PR TITLE
fix: revert default bind address to 0.0.0.0

### DIFF
--- a/pkg/chassis/config.go
+++ b/pkg/chassis/config.go
@@ -88,7 +88,7 @@ func LoadConfig() Config {
 }
 
 func setDefaults(v *viper.Viper) {
-	v.SetDefault("service.network.bind_address", "localhost")
+	v.SetDefault("service.network.bind_address", "0.0.0.0")
 	v.SetDefault("service.network.bind_port", 8090)
 	v.SetDefault("service.env", "local")
 	v.SetDefault("service.logging.level", "info")


### PR DESCRIPTION
In #66 the default bind address was changed to `localhost` which means that any container based deployment has to specify a config override to `0.0.0.0` which seems backwards. Reverting that change so the default bind address is once again `0.0.0.0`.